### PR TITLE
Add verification for installer

### DIFF
--- a/Documentation/install/aws/aws-terraform.md
+++ b/Documentation/install/aws/aws-terraform.md
@@ -14,11 +14,24 @@ Generally, the AWS platform templates adhere to the standards defined by the pro
 
 ### Download and extract Tectonic Installer
 
-Open a new terminal, and run the following commands to download and extract Tectonic Installer.
+Open a new terminal and run the following command to download Tectonic Installer.
 
 ```bash
 $ curl -O https://releases.tectonic.com/tectonic-1.7.3-tectonic.1.tar.gz # download
-$ tar xzvf tectonic-1.7.3-tectonic.1.tar.gz # extract the tarball
+```
+
+Verify the release has been signed by the [CoreOS App Signing Key][verification-key].
+
+```bash
+$ gpg2 --keyserver pgp.mit.edu --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
+$ gpg2 --verify tectonic-1.7.3-tectonic.1.tar.gz.asc tectonic-1.7.3-tectonic.1.tar.gz
+# gpg2: Good signature from "CoreOS Application Signing Key <security@coreos.com>"
+```
+
+Extract the tarball and navigate to the `tectonic` directory.
+
+```bash
+$ tar xzvf tectonic-1.7.3-tectonic.1.tar.gz
 $ cd tectonic
 ```
 
@@ -125,3 +138,4 @@ See the [troubleshooting][troubleshooting] document for workarounds for bugs tha
 [uninstall]: uninstall.md
 [scale-aws]: ../../admin/aws-scale.md
 [release-notes]: https://coreos.com/tectonic/releases/
+[verification-key]: https://coreos.com/security/app-signing-key/

--- a/Documentation/install/azure/azure-terraform.md
+++ b/Documentation/install/azure/azure-terraform.md
@@ -62,11 +62,24 @@ Also ensure the SSH known_hosts file doesn't have old records for the API DNS na
 
 ### Download and extract Tectonic Installer
 
-Open a new terminal and run the following commands to download and extract Tectonic Installer:
+Open a new terminal and run the following command to download Tectonic Installer.
 
 ```bash
 $ curl -O https://releases.tectonic.com/tectonic-1.7.3-tectonic.1.tar.gz # download
-$ tar xzvf tectonic-1.7.3-tectonic.1.tar.gz # extract the tarball
+```
+
+Verify the release has been signed by the [CoreOS App Signing Key][verification-key].
+
+```bash
+$ gpg2 --keyserver pgp.mit.edu --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
+$ gpg2 --verify tectonic-1.7.3-tectonic.1-tar-gz.asc tectonic-1.7.3-tectonic.1-tar.gz
+# gpg2: Good signature from "CoreOS Application Signing Key <security@coreos.com>"
+```
+
+Extract the tarball and navigate to the `tectonic` directory.
+
+```bash
+$ tar xzvf tectonic-1.7.3-tectonic.1.tar.gz
 $ cd tectonic
 ```
 
@@ -276,3 +289,4 @@ See the [installer troubleshooting][troubleshooting] document for known problem 
 [release-notes]: https://coreos.com/tectonic/releases/
 [troubleshooting]: ../../troubleshooting/installer-terraform.md
 [vars]: https://github.com/coreos/tectonic-installer/tree/master/Documentation/variables/config.md
+[verification-key]: https://coreos.com/security/app-signing-key/ 

--- a/Documentation/install/bare-metal/metal-terraform.md
+++ b/Documentation/install/bare-metal/metal-terraform.md
@@ -19,10 +19,23 @@ For a complete list of requirements, see [Bare Metal Installation requirements][
 
 ### Download and extract Tectonic Installer
 
-Open a new terminal, and run the following commands to download and extract Tectonic Installer.
+Open a new terminal and run the following command to download Tectonic Installer.
 
 ```bash
-$ curl -O https://releases.tectonic.com/tectonic-1.7.3-tectonic.1.tar.gz
+$ curl -O https://releases.tectonic.com/tectonic-1.7.3-tectonic.1.tar.gz # download
+```
+
+Verify the release has been signed by the [CoreOS App Signing Key][verification-key].
+
+```bash
+$ gpg2 --keyserver pgp.mit.edu --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
+$ gpg2 --verify tectonic-1.7.3-tectonic.1-tar-gz.asc tectonic-1.7.3-tectonic.1-tar.gz
+# gpg2: Good signature from "CoreOS Application Signing Key <security@coreos.com>"
+```
+
+Extract the tarball and navigate to the `tectonic` directory.
+
+```bash
 $ tar xzvf tectonic-1.7.3-tectonic.1.tar.gz
 $ cd tectonic
 ```
@@ -137,3 +150,4 @@ For more information on working with installed clusters, see [Scaling Tectonic b
 [network-setup]: https://coreos.com/matchbox/docs/latest/network-setup.html
 [matchbox-latest]: https://coreos.com/matchbox/docs/latest/
 [dns]: index.md#dns
+[verification-key]: https://coreos.com/security/app-signing-key/ 

--- a/Documentation/install/openstack/openstack-terraform.md
+++ b/Documentation/install/openstack/openstack-terraform.md
@@ -21,11 +21,24 @@ Replace `<flavor>` with either option in the following commands. Now we're ready
 
 ### Download and extract Tectonic Installer
 
-Open a new terminal, and run the following commands to download and extract Tectonic Installer.
+Open a new terminal and run the following command to download Tectonic Installer.
 
 ```bash
 $ curl -O https://releases.tectonic.com/tectonic-1.7.3-tectonic.1.tar.gz # download
-$ tar xzvf tectonic-1.7.3-tectonic.1.tar.gz # extract the tarball
+```
+
+Verify the release has been signed by the [CoreOS App Signing Key][verification-key].
+
+```bash
+$ gpg2 --keyserver pgp.mit.edu --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
+$ gpg2 --verify tectonic-1.7.3-tectonic.1-tar-gz.asc tectonic-1.7.3-tectonic.1-tar.gz
+# gpg2: Good signature from "CoreOS Application Signing Key <security@coreos.com>"
+```
+
+Extract the tarball and navigate to the `tectonic` directory.
+
+```bash
+$ tar xzvf tectonic-1.7.3-tectonic.1.tar.gz
 $ cd tectonic
 ```
 
@@ -199,3 +212,4 @@ See the [troubleshooting][troubleshooting] document for workarounds for bugs tha
 [troubleshooting]: ../../troubleshooting/faq.md
 [openstack-neutron-vars]: https://github.com/coreos/tectonic-installer/tree/master/Documentation/variables/openstack-neutron.md
 [release-notes]: https://coreos.com/tectonic/releases/
+[verification-key]: https://coreos.com/security/app-signing-key/

--- a/Documentation/install/vmware/vmware-terraform.md
+++ b/Documentation/install/vmware/vmware-terraform.md
@@ -65,11 +65,24 @@ The following steps must be executed on a machine that has network connectivity 
 
 ### Download and extract Tectonic Installer
 
-Open a new terminal, and run the following commands to download and extract Tectonic Installer.
+Open a new terminal and run the following command to download Tectonic Installer.
 
 ```bash
 $ curl -O https://releases.tectonic.com/tectonic-1.7.3-tectonic.1.tar.gz # download
-$ tar xzvf tectonic-1.7.3-tectonic.1.tar.gz # extract the tarball
+```
+
+Verify the release has been signed by the [CoreOS App Signing Key][verification-key].
+
+```bash
+$ gpg2 --keyserver pgp.mit.edu --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
+$ gpg2 --verify tectonic-1.7.3-tectonic.1-tar-gz.asc tectonic-1.7.3-tectonic.1-tar.gz
+# gpg2: Good signature from "CoreOS Application Signing Key <security@coreos.com>"
+```
+
+Extract the tarball and navigate to the `tectonic` directory.
+
+```bash
+$ tar xzvf tectonic-1.7.3-tectonic.1.tar.gz
 $ cd tectonic
 ```
 
@@ -190,3 +203,4 @@ $ terraform destroy ../../platforms/vmware
 [vmware]: https://github.com/coreos/tectonic-installer/tree/master/Documentation/variables/vmware.md
 [vars]: https://github.com/coreos/tectonic-installer/tree/master/Documentation/variables/config.md
 [troubleshooting]: ../../troubleshooting/faq.md
+[verification-key]: https://coreos.com/security/app-signing-key/

--- a/Documentation/tutorials/aws/installing-tectonic.md
+++ b/Documentation/tutorials/aws/installing-tectonic.md
@@ -41,14 +41,22 @@ Having completed the AWS installation requirements, you are now ready to downloa
 
 Make sure a current version of either the Google Chrome or Mozilla Firefox browser is set as the default on the workstation where the installer will run.
 
-1. Download and run the Tectonic installer by opening a new terminal, and running the following command:
+1. Download and run the Tectonic installer by opening a new terminal and running the following command:
 ```
 $ curl -O https://releases.tectonic.com/tectonic-1.7.3-tectonic.1.tar.gz
 ```
 
-2. Double click the tarball to extract it, then navigate to the tectonic/tectonic-installer folder.
-3. Double click the folder for your operating system.
-4. Double click the installer to launch it.
+2. Verify the release has been signed by the [CoreOS App Signing Key][verification-key].
+
+```bash
+$ gpg2 --keyserver pgp.mit.edu --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
+$ gpg2 --verify tectonic-1.7.3-tectonic.1-tar-gz.asc tectonic-1.7.3-tectonic.1-tar.gz
+# gpg2: Good signature from "CoreOS Application Signing Key <security@coreos.com>"
+```
+
+3. Double click the tarball to extract it, then navigate to the tectonic/tectonic-installer folder.
+4. Double click the folder for your operating system.
+5. Double click the installer to launch it.
 
 A browser window will open the Tectonic Installer to walk you through the setup process and provision your cluster.
 
@@ -177,3 +185,4 @@ Click *Configure kubectl* or *Deploy Application* to open CoreOS tutorials for t
 [first-app]: first-app.md
 [creating-aws]: creating-aws.md
 [aws-troubleshooting]: ../../install/aws/troubleshooting.md
+[verification-key]: https://coreos.com/security/app-signing-key/

--- a/Documentation/tutorials/azure/install.md
+++ b/Documentation/tutorials/azure/install.md
@@ -121,10 +121,23 @@ Register for a [Tectonic Account][register], free for up to 10 nodes. The Tecton
 
 ### Download and extract Tectonic Installer
 
-Open a new terminal and run the following commands to download and extract Tectonic Installer:
+Open a new terminal and run the following command to download Tectonic Installer.
 
 ```bash
-$ curl -O https://releases.tectonic.com/tectonic-1.7.3-tectonic.1.tar.gz
+$ curl -O https://releases.tectonic.com/tectonic-1.7.3-tectonic.1.tar.gz # download
+```
+
+Verify the release has been signed by the [CoreOS App Signing Key][verification-key].
+
+```bash
+$ gpg2 --keyserver pgp.mit.edu --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
+$ gpg2 --verify tectonic-1.7.3-tectonic.1-tar-gz.asc tectonic-1.7.3-tectonic.1-tar.gz
+# gpg2: Good signature from "CoreOS Application Signing Key <security@coreos.com>"
+```
+
+Extract the tarball and navigate to the `tectonic` directory.
+
+```bash
 $ tar xzvf tectonic-1.7.3-tectonic.1.tar.gz
 $ cd tectonic
 ```
@@ -224,3 +237,4 @@ When `terraform apply` is complete, the Tectonic console will be available at `h
 [first-app]: first-app.md
 [register]: https://account.coreos.com/signup/summary/tectonic-2016-12
 [vars]: https://github.com/coreos/tectonic-installer/tree/master/Documentation/variables/config.md
+[verification-key]: https://coreos.com/security/app-signing-key/


### PR DESCRIPTION
See [DOCS-68](https://coreosdev.atlassian.net/browse/DOCS-68) on JIRA for more detail.

## Changes in this PR
Adds a gpg verification step to the following docs:
* `install/aws/aws-terraform.md`
* `install/azure/azure-terraform.md`
* `install/bare-metal/metal-terraform.md`
* `install/openstack/openstack-terraform.md`
* `install/vmware/vmware-terraform.md`
* `tutorials/aws/installing-tectonic.md`
* `tutorials/azure/install.md`