### PR TITLE
Dereference the container log symlinks so they are saved

### DIFF
--- a/Documentation/troubleshooting/bootkube_recovery_tool.md
+++ b/Documentation/troubleshooting/bootkube_recovery_tool.md
@@ -31,7 +31,7 @@ Before recovering a cluster, remove the docker state, etcd state, and active man
 
 1. Back up `/var/log/containers` for later inspection:
 
-   `tar -cvzf /var/log/containers containerlogs.tgz`
+   `tar -hcvzf containerlogs.tgz /var/log/containers`
 
 2.  Stop the kubelet service:
 


### PR DESCRIPTION
There were two problems with the original command.

1. It had the archive file in the wrong position
2. The files in /var/log/containers are symlinks and so need to be dereferenced when making the archive