### PR TITLE
Only one command needs to have backup.db owned by core user

### DIFF
--- a/Documentation/troubleshooting/bootkube_recovery_tool.md
+++ b/Documentation/troubleshooting/bootkube_recovery_tool.md
@@ -88,11 +88,7 @@ Use the latest version of `bootkube` when using the `bootkube recover` command, 
 
 3. Change directory to navigate to the respective installer directory.
 
-4. Provide necessary permissions to the group `core` for the etcd backup file,  `backup.db`.
-
-    `$ sudo chown core:core /root/backup.db`
-
-5. Run `bootkube recover` with a flag corresponding to the current state of the cluster:  
+4. Run `bootkube recover` with a flag corresponding to the current state of the cluster:
 
     `$ sudo ./bootkube recover --recovery-dir=/home/core/recovered --etcd-backup-file=/root/backup.db --kubeconfig=/etc/kubernetes/kubeconfig`
 
@@ -129,7 +125,7 @@ Use the latest version of `bootkube` when using the `bootkube recover` command, 
       Writing asset: /home/core/recovered/auth/kubeconfig
       ```  
 
-6. Run `bootkube start` to reboot the cluster.
+5. Run `bootkube start` to reboot the cluster.
 
     `$ sudo ./bootkube start --asset-dir=/home/core/recovered`
 
@@ -198,7 +194,8 @@ Replace `etcd-server-ip` with the IP address of your etcd cluster.
 If using self-hosted etcd, recovery is supported via reading from an etcd backup file:
 
 ```
-$ bootkube recover --recovery-dir=recovered --etcd-backup-file=backup --kubeconfig=/etc/kubernetes/kubeconfig
+$ sudo chown core:core /root/backup.db
+$ bootkube recover --recovery-dir=recovered --etcd-backup-file=/root/backup.db --kubeconfig=/etc/kubernetes/kubeconfig
 ```
 
 In addition to rebooting the control plane, this will also destroy and recreate the self-hosted etcd cluster by using the backup.


### PR DESCRIPTION
The less needed to do during a recovery better and I think leaving the etcd backup readable by core is bad. Arguably you don't even need it in the one case it is used if you are ok with all the recovery files being owned by root instead of core.

Personally I do the recover command as root because I find it less error prone to start the recovery by first running `sudo su -` and running each step as root and dropping sudo all together. The last thing you want is a child process or a piped command to fail because sudo wasn't tacked on.