### PR TITLE
Preserve the most recent etcd backup file

### DIFF
--- a/Documentation/troubleshooting/bootkube_recovery_tool.md
+++ b/Documentation/troubleshooting/bootkube_recovery_tool.md
@@ -56,7 +56,7 @@ Before recovering a cluster, remove the docker state, etcd state, and active man
 
     1. Back up the associated data.
 
-       `$ sudo cp $(sudo find /var/etcd/ -iname db) /root/backup.db`
+       `$ sudo cp $(sudo find /var/etcd/ -iname db -exec ls -1t {} + | head -n1) /root/backup.db`
 
     2. Remove the data from the etcd directory:
 


### PR DESCRIPTION
I have run into a case where there were two etcd live snapshot files in /var/etcd. This command copies the most recent version.