### PR TITLE
docs: Remove terraformrc setup obsoleted with Terraform 0.10

### DIFF
--- a/Documentation/install/aws/aws-terraform.md
+++ b/Documentation/install/aws/aws-terraform.md
@@ -37,24 +37,16 @@ $ cd tectonic
 
 ### Initialize and configure Terraform
 
-Start by setting the `INSTALLER_PATH` to the location of your platform's Tectonic installer. The platform should be `darwin` or `linux`. We also need to add the `terraform` binary to our `PATH`.
+We need to add the `terraform` binary to our `PATH`. The platform should be `darwin` or `linux`.
 
 ```bash
-$ export INSTALLER_PATH=$(pwd)/tectonic-installer/darwin/installer # Edit the platform name.
 $ export PATH=$PATH:$(pwd)/tectonic-installer/darwin # Put the `terraform` binary in the PATH
 ```
 
-Make a copy of the Terraform configuration file for the system. Do not share this configuration file as it is specific to the machine.
+Download the Tectonic Terraform modules.
 
 ```bash
-$ sed "s|<PATH_TO_INSTALLER>|$INSTALLER_PATH|g" terraformrc.example > .terraformrc
-$ export TERRAFORM_CONFIG=$(pwd)/.terraformrc
-```
-
-Next, get the modules that Terraform will use to create the cluster resources:
-
-```bash
-$ terraform get platforms/aws
+$ terraform init platforms/aws
 ```
 
 Configure your AWS credentials. See the [AWS docs][env] for details.

--- a/Documentation/install/azure/azure-terraform.md
+++ b/Documentation/install/azure/azure-terraform.md
@@ -87,31 +87,18 @@ $ cd tectonic
 
 #### Set INSTALLER_PATH
 
-Start by setting `INSTALLER_PATH` to the location of the installation host's Tectonic installer platform. The platform should be one of `darwin` or `linux`.
+We need to add the `terraform` binary to our `PATH`. The platform should be `darwin` or `linux`.
 
 ```bash
-$ export INSTALLER_PATH=$(pwd)/tectonic-installer/darwin/installer # Edit the platform name.
 $ export PATH=$PATH:$(pwd)/tectonic-installer/darwin # Put the `terraform` binary on PATH
-```
-
-#### Copy and configure .terraformrc
-
-Make a copy of the Terraform configuration file. Do not share this configuration file as it is specific to the install host.
-
-```bash
-$ sed "s|<PATH_TO_INSTALLER>|$INSTALLER_PATH|g" terraformrc.example > .terraformrc
-$ export TERRAFORM_CONFIG=$(pwd)/.terraformrc
 ```
 
 #### Get Terraform's Azure modules
 
-Next, get the modules for the Azure platform that Terraform will use to create cluster resources:
+Download the Tectonic Terraform modules.
 
-```
-$ terraform get platforms/azure
-Get: file:///Users/tectonic-installer/modules/azure/vnet
-Get: file:///Users/tectonic-installer/modules/azure/etcd
-...
+```bash
+$ terraform init platforms/azure
 ```
 
 ### Generate credentials with Azure CLI

--- a/Documentation/install/azure/azure-terraform.md
+++ b/Documentation/install/azure/azure-terraform.md
@@ -85,17 +85,13 @@ $ cd tectonic
 
 ### Initialize and configure Terraform
 
-#### Set INSTALLER_PATH
-
-We need to add the `terraform` binary to our `PATH`. The platform should be `darwin` or `linux`.
+Add the `terraform` binary to the `PATH`. The platform should be `darwin` or `linux`.
 
 ```bash
 $ export PATH=$PATH:$(pwd)/tectonic-installer/darwin # Put the `terraform` binary on PATH
 ```
 
-#### Get Terraform's Azure modules
-
-Download the Tectonic Terraform modules.
+Initialize the Tectonic Terraform modules.
 
 ```bash
 $ terraform init platforms/azure

--- a/Documentation/install/openstack/openstack-terraform.md
+++ b/Documentation/install/openstack/openstack-terraform.md
@@ -44,24 +44,16 @@ $ cd tectonic
 
 ### Initialize and configure Terraform
 
-Start by setting the `INSTALLER_PATH` to the location of your platform's Tectonic installer. The platform should be `darwin` or `linux`.
+We need to add the `terraform` binary to our `PATH`. The platform should be `darwin` or `linux`.
 
 ```bash
-$ export INSTALLER_PATH=$(pwd)/tectonic-installer/linux/installer # Edit the platform name.
 $ export PATH=$PATH:$(pwd)/tectonic-installer/linux # Put the `terraform` binary in our PATH
 ```
 
-Make a copy of the Terraform configuration file for our system. Do not share this configuration file as it is specific to your machine.
+Download the Tectonic Terraform modules.
 
 ```bash
-$ sed "s|<PATH_TO_INSTALLER>|$INSTALLER_PATH|g" terraformrc.example > .terraformrc
-$ export TERRAFORM_CONFIG=$(pwd)/.terraformrc
-```
-
-Next, get the modules that Terraform will use to create the cluster resources:
-
-```
-$ terraform get platforms/openstack/<flavor>
+$ terraform init platforms/openstack/<flavor>
 ```
 
 Configure your AWS credentials for setting up Route 53 DNS record entries. See the [AWS docs][env] for details.


### PR DESCRIPTION
Terraform 0.10 doesn't require a custom `terraformrc` file and the example was removed in https://github.com/coreos/tectonic-installer/commit/16babc9c2dcb933d45a360092e20f0b4b0fd877e. 

I didn't touch the metal docs because there's more setup required than `terraform init`.