### PR TITLE
Versions strings: underscores and t.3

### DIFF
--- a/Documentation/hack/centos-workers.md
+++ b/Documentation/hack/centos-workers.md
@@ -6,7 +6,7 @@ This is unofficial. The author does not update, maintain, or support this setup.
 
 ## CoreOS Tectonic
 
-Provision a Tectonic `1.7.3-tectonic.2` bare-metal cluster (Container Linux, 1 controller, 2 workers) in the usual way with [matchbox](https://github.com/coreos/matchbox) and the Tectonic [Installer](https://coreos.com/tectonic/docs/latest/install/bare-metal/index.html).
+Provision a Tectonic `1.7.3-tectonic.3` bare-metal cluster (Container Linux, 1 controller, 2 workers) in the usual way with [matchbox](https://github.com/coreos/matchbox) and the Tectonic [Installer](https://coreos.com/tectonic/docs/latest/install/bare-metal/index.html).
 
 Locally, you may PXE boot QEMU/KVM nodes via Tectonic and matchbox on the `metal0` bridge.
 

--- a/Documentation/install/aws/aws-terraform.md
+++ b/Documentation/install/aws/aws-terraform.md
@@ -36,14 +36,14 @@ Verify the release has been signed by the [CoreOS App Signing Key][verification-
 
 ```bash
 $ gpg2 --keyserver pgp.mit.edu --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
-$ gpg2 --verify tectonic-1.7.3-tectonic.2.tar.gz.asc tectonic-1.7.3-tectonic.2.tar.gz
+$ gpg2 --verify tectonic_1.7.3-tectonic.3.tar.gz.asc tectonic_1.7.3-tectonic.3.tar.gz
 # gpg2: Good signature from "CoreOS Application Signing Key <security@coreos.com>"
 ```
 
 Extract the tarball and navigate to the `tectonic` directory.
 
 ```bash
-$ tar xzvf tectonic-1.7.3-tectonic.2.tar.gz
+$ tar xzvf tectonic_1.7.3-tectonic.3.tar.gz
 $ cd tectonic
 ```
 

--- a/Documentation/install/aws/index.md
+++ b/Documentation/install/aws/index.md
@@ -29,7 +29,7 @@ Download the [Tectonic installer][latest-tectonic-release].
 
 ```bash
 wget https://releases.tectonic.com/releases/tectonic_1.7.3-tectonic.3.tar.gz
-tar xzvf tectonic-1.7.3-tectonic.2.tar.gz
+tar xzvf tectonic_1.7.3-tectonic.3.tar.gz
 cd tectonic
 ```
 

--- a/Documentation/install/azure/azure-terraform.md
+++ b/Documentation/install/azure/azure-terraform.md
@@ -79,14 +79,14 @@ Verify the release has been signed by the [CoreOS App Signing Key][verification-
 
 ```bash
 $ gpg2 --keyserver pgp.mit.edu --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
-$ gpg2 --verify tectonic-1.7.3-tectonic.2-tar-gz.asc tectonic-1.7.3-tectonic.2-tar.gz
+$ gpg2 --verify tectonic_1.7.3-tectonic.3-tar-gz.asc tectonic_1.7.3-tectonic.3-tar.gz
 # gpg2: Good signature from "CoreOS Application Signing Key <security@coreos.com>"
 ```
 
 Extract the tarball and navigate to the `tectonic` directory.
 
 ```bash
-$ tar xzvf tectonic-1.7.3-tectonic.2.tar.gz
+$ tar xzvf tectonic_1.7.3-tectonic.3.tar.gz
 $ cd tectonic
 ```
 

--- a/Documentation/install/bare-metal/index.md
+++ b/Documentation/install/bare-metal/index.md
@@ -163,7 +163,7 @@ Download [Tectonic Installer][latest-tectonic-release].
 
 ```sh
 wget https://releases.tectonic.com/releases/tectonic_1.7.3-tectonic.3.tar.gz
-tar xzvf tectonic-1.7.3-tectonic.2.tar.gz
+tar xzvf tectonic_1.7.3-tectonic.3.tar.gz
 cd tectonic/tectonic-installer
 ```
 

--- a/Documentation/install/bare-metal/metal-terraform.md
+++ b/Documentation/install/bare-metal/metal-terraform.md
@@ -40,14 +40,14 @@ Verify the release has been signed by the [CoreOS App Signing Key][verification-
 
 ```bash
 $ gpg2 --keyserver pgp.mit.edu --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
-$ gpg2 --verify tectonic-1.7.3-tectonic.2-tar-gz.asc tectonic-1.7.3-tectonic.2-tar.gz
+$ gpg2 --verify tectonic_1.7.3-tectonic.3-tar-gz.asc tectonic_1.7.3-tectonic.3-tar.gz
 # gpg2: Good signature from "CoreOS Application Signing Key <security@coreos.com>"
 ```
 
 Extract the tarball and navigate to the `tectonic` directory.
 
 ```bash
-$ tar xzvf tectonic-1.7.3-tectonic.2.tar.gz
+$ tar xzvf tectonic_1.7.3-tectonic.3.tar.gz
 $ cd tectonic
 ```
 

--- a/Documentation/install/openstack/openstack-terraform.md
+++ b/Documentation/install/openstack/openstack-terraform.md
@@ -42,14 +42,14 @@ Verify the release has been signed by the [CoreOS App Signing Key][verification-
 
 ```bash
 $ gpg2 --keyserver pgp.mit.edu --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
-$ gpg2 --verify tectonic-1.7.3-tectonic.2-tar-gz.asc tectonic-1.7.3-tectonic.2-tar.gz
+$ gpg2 --verify tectonic_1.7.3-tectonic.3-tar-gz.asc tectonic_1.7.3-tectonic.3-tar.gz
 # gpg2: Good signature from "CoreOS Application Signing Key <security@coreos.com>"
 ```
 
 Extract the tarball and navigate to the `tectonic` directory.
 
 ```bash
-$ tar xzvf tectonic-1.7.3-tectonic.2.tar.gz
+$ tar xzvf tectonic_1.7.3-tectonic.3.tar.gz
 $ cd tectonic
 ```
 

--- a/Documentation/install/vmware/vmware-terraform.md
+++ b/Documentation/install/vmware/vmware-terraform.md
@@ -86,14 +86,14 @@ Verify the release has been signed by the [CoreOS App Signing Key][verification-
 
 ```bash
 $ gpg2 --keyserver pgp.mit.edu --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
-$ gpg2 --verify tectonic-1.7.3-tectonic.2-tar-gz.asc tectonic-1.7.3-tectonic.2-tar.gz
+$ gpg2 --verify tectonic_1.7.3-tectonic.3-tar-gz.asc tectonic_1.7.3-tectonic.3-tar.gz
 # gpg2: Good signature from "CoreOS Application Signing Key <security@coreos.com>"
 ```
 
 Extract the tarball and navigate to the `tectonic` directory.
 
 ```bash
-$ tar xzvf tectonic-1.7.3-tectonic.2.tar.gz
+$ tar xzvf tectonic_1.7.3-tectonic.3.tar.gz
 $ cd tectonic
 ```
 

--- a/Documentation/troubleshooting/tectonic-upgrade.md
+++ b/Documentation/troubleshooting/tectonic-upgrade.md
@@ -15,7 +15,7 @@ To resolve these issues, delete each affected Pod and allow the StatefulSet to r
 
 To update to 1.7.1-tectonic.1, first update to 1.6.7-tectonic.2. Updates to 1.7.1-tectonic.1 from versions previous to 1.6.7-tectonic.2 will fail.
 
-### Switching to 1.7 channel before updating to v1.6.7_tectonic.2.
+### Switching to 1.7 channel before updating to v1.6.7-tectonic.2.
 
 If Tectonic Console was used to switch to the `Tectonic-1.7-preproduction` or `Tectonic-1.7-production` channel from v1.6.7-tectonic.1 or previous, first revert to the channel listed before update. Then wait for the next update check. When Tectonic Console lists the option, switch to `Tectonic-1.6.7`. Once that update is complete, use the Console to update to `Tectonic-1.7`.
 

--- a/Documentation/tutorials/aws/installing-tectonic.md
+++ b/Documentation/tutorials/aws/installing-tectonic.md
@@ -45,7 +45,7 @@ $ curl -O https://releases.tectonic.com/releases/tectonic_1.7.3-tectonic.3.tar.g
 
 ```bash
 $ gpg2 --keyserver pgp.mit.edu --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
-$ gpg2 --verify tectonic-1.7.3-tectonic.2-tar-gz.asc tectonic-1.7.3-tectonic.2-tar.gz
+$ gpg2 --verify tectonic_1.7.3-tectonic.3-tar-gz.asc tectonic_1.7.3-tectonic.3-tar.gz
 # gpg2: Good signature from "CoreOS Application Signing Key <security@coreos.com>"
 ```
 
@@ -57,7 +57,7 @@ A browser window will open Tectonic Installer to walk you through the setup proc
 
 If you prefer to work within the terminal, extract and launch the Installer using:
 ```bash
-tar xzvf tectonic-1.7.3-tectonic.2.tar.gz # to extract the tarball
+tar xzvf tectonic_1.7.3-tectonic.3.tar.gz # to extract the tarball
 $ cd tectonic/tectonic-installer # to change to the previously untarred directory
 $ ./$PLATFORM/installer # to run Tectonic Installer
 ```

--- a/Documentation/tutorials/azure/install.md
+++ b/Documentation/tutorials/azure/install.md
@@ -138,14 +138,14 @@ Verify the release has been signed by the [CoreOS App Signing Key][verification-
 
 ```bash
 $ gpg2 --keyserver pgp.mit.edu --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
-$ gpg2 --verify tectonic-1.7.3-tectonic.2-tar-gz.asc tectonic-1.7.3-tectonic.2-tar.gz
+$ gpg2 --verify tectonic_1.7.3-tectonic.3-tar-gz.asc tectonic_1.7.3-tectonic.3-tar.gz
 # gpg2: Good signature from "CoreOS Application Signing Key <security@coreos.com>"
 ```
 
 Extract the tarball and navigate to the `tectonic` directory.
 
 ```bash
-$ tar xzvf tectonic-1.7.3-tectonic.2.tar.gz
+$ tar xzvf tectonic_1.7.3-tectonic.3.tar.gz
 $ cd tectonic
 ```
 


### PR DESCRIPTION
The release file name replaced a hyphen with an underscore between 1.7.3-t.2 and 1.7.3-t.3, viz:
tectonic-1.7.3-tectonic.2
vs
tectonic_1.73-tectonic.3
