### PR TITLE
Fix $PATH precedence

### DIFF
--- a/Documentation/install/aws/aws-terraform.md
+++ b/Documentation/install/aws/aws-terraform.md
@@ -54,7 +54,7 @@ $ cd tectonic
 Add the `terraform` binary to our `PATH`. The platform should be `darwin` or `linux`.
 
 ```bash
-$ export PATH=$PATH:$(pwd)/tectonic-installer/darwin # Put the `terraform` binary on the PATH
+$ export PATH=$(pwd)/tectonic-installer/darwin:$PATH # Put the `terraform` binary on the PATH
 ```
 
 Download the Tectonic Terraform modules.

--- a/Documentation/install/azure/azure-terraform.md
+++ b/Documentation/install/azure/azure-terraform.md
@@ -97,7 +97,7 @@ $ cd tectonic
 Add the `terraform` binary to the `PATH`. The platform should be `darwin` or `linux`.
 
 ```bash
-$ export PATH=$PATH:$(pwd)/tectonic-installer/darwin # Put the `terraform` binary on PATH
+$ export PATH=$(pwd)/tectonic-installer/darwin:$PATH # Put the `terraform` binary on PATH
 ```
 
 Initialize the Tectonic Terraform modules.

--- a/Documentation/install/bare-metal/metal-terraform.md
+++ b/Documentation/install/bare-metal/metal-terraform.md
@@ -59,7 +59,7 @@ Start by setting the `INSTALLER_PATH` to the location of your platform's Tectoni
 
 ```bash
 $ export INSTALLER_PATH=$(pwd)/tectonic-installer/linux/installer
-$ export PATH=$PATH:$(pwd)/tectonic-installer/linux
+$ export PATH=$(pwd)/tectonic-installer/linux:$PATH
 ```
 
 Next, get the modules that Terraform will use to create the cluster resources:

--- a/Documentation/install/openstack/openstack-terraform.md
+++ b/Documentation/install/openstack/openstack-terraform.md
@@ -60,7 +60,7 @@ $ cd tectonic
 We need to add the `terraform` binary to our `PATH`. The platform should be `darwin` or `linux`.
 
 ```bash
-$ export PATH=$PATH:$(pwd)/tectonic-installer/linux # Put the `terraform` binary in our PATH
+$ export PATH=$(pwd)/tectonic-installer/linux:$PATH # Put the `terraform` binary in our PATH
 ```
 
 Download the Tectonic Terraform modules.


### PR DESCRIPTION
In Unix systems, the $PATH is searched from the beginning to end.
Thereby paths mentioned first take precedence over paths mentioned
later. The shipped `terraform` binary should be choosen before a
possible locally installed `terraform` binary. This patch makes sure,
the shipped version takes precedence over any other possible local
version.

@alexsomesan @squat Please correct me if I am wrong.