### PR TITLE
Azure: Move deploy secrets into environment

### DIFF
--- a/Documentation/install/azure/azure-terraform.md
+++ b/Documentation/install/azure/azure-terraform.md
@@ -66,7 +66,7 @@ Reference the absolute path of the **_public_** component of the SSH key in `tec
 Without this, terraform is not able to SSH copy the assets and start bootkube.
 Also ensure the SSH known_hosts file doesn't have old records for the API DNS name, because key fingerprints will not match.
 
-## Getting Started
+## Deploying the Tectonic cluster
 
 ### Download and extract Tectonic Installer
 
@@ -94,7 +94,7 @@ $ cd tectonic
 
 ### Initialize and configure Terraform
 
-Add the `terraform` binary to the `PATH`. The platform should be `darwin` or `linux`.
+Add the `terraform` binary to the `PATH`. The platform is one of `darwin` or `linux`.
 
 ```bash
 $ export PATH=$PATH:$(pwd)/tectonic-installer/darwin # Put the `terraform` binary on PATH
@@ -161,11 +161,11 @@ $ export ARM_CLIENT_SECRET=generated-pass
 $ export ARM_TENANT_ID=generated-tenant
 ```
 
-With the environment set, it's time to specify the deployment details for the cluster.
+With the Azure environment set, specify the deployment details for the cluster.
 
-## Customize the deployment
+## Tailor the deployment
 
-Possible customizations to the base installation are listed in `examples/terraform.tfvars.azure`. Choose a cluster name to identify the cluster. Export an environment variable with the chosen cluster name. In this example, `my-cluster` is used.
+Choose a cluster name to identify the cluster. Export an environment variable with the chosen cluster name. This example names the cluster `my-cluster`.
 
 ```
 $ export CLUSTER=my-cluster
@@ -178,19 +178,36 @@ $ mkdir -p build/${CLUSTER}
 $ cp examples/terraform.tfvars.azure build/${CLUSTER}/terraform.tfvars
 ```
 
-Edit the parameters in `build/$CLUSTER/terraform.tfvars` with the deployment's Azure details, domain name, license, and pull secret. [View all of the Azure specific options][azure-vars] and [the common Tectonic variables][vars].
-
 ### Key values for basic Azure deployment
 
-These are the basic values that must be adjusted for each Tectonic deployment on Azure. See the details of each value in the [terraform.tfvars][terraform-tvars] file.
+These are the basic values that must be adjusted for each Tectonic deployment on Azure.
 
-* `tectonic_admin_email` - For the initial Console login
-* `tectonic_admin_password_hash` - Bcrypted value
-* `tectonic_azure_client_secret` - As in `ARM_CLIENT_SECRET` above
-* `tectonic_azure_location` - Enter the region's Name (for example: `centralus`)
+#### Environment variables
+
+Set these sensitive values in the environment. Terraform will encrypt them before storage or transport:
+
+* `TF_VAR_tectonic_admin_email` - String giving the email address used as user name for the initial Console login
+* `TF_VAR_tectonic_admin_password` - Plaintext password string for initial Console login
+* `TF_VAR_tectonic_azure_client_secret` - Generated, obfuscated password string matching `ARM_CLIENT_SECRET` and `password` value from `az ad` output, above
+* `TF_VAR_tectonic_azure_location` - Lowercase catenated string giving the Azure location name (example: `centralus`)
+
+For example, in the `bash(1)` shell, replace the quoted values with those for the cluster being deployed and run the following commands:
+
+```bash
+$ export TF_VAR_tectonic_admin_email="admin@example.com"
+$ export TF_VAR_tectonic_admin_password="pl41nT3xt"
+$ export TF_VAR_tectonic_azure_client_secret=${ARM_CLIENT_SECRET}
+$ export TF_VAR_tectonic_azure_location="centralus"
+...
+```
+
+#### Terraform variables file
+
+Edit the parameters in `build/$CLUSTER/terraform.tfvars` with the deployment's Azure details, domain name, license, and pull secret. See the details of each value below in the [terraform.tfvars][terraform-tvars] file, or check the complete list of [Azure specific options][azure-vars] and [the common Tectonic variables][vars].
+
 * `tectonic_azure_ssh_key` - Full path to the public key part of the key added to `ssh-agent` above
 * `tectonic_base_domain` - The DNS domain or subdomain delegated to an Azure DNS zone above
-* `tectonic_azure_external_dns_zone_id` - Get with `az network dns zone list`
+* `tectonic_azure_external_dns_zone_id` - Value of `id` in `az network dns zone list` output
 * `tectonic_cluster_name` - Usually matches `$CLUSTER` as set above
 * `tectonic_license_path` - Full path to `tectonic-license.txt` file downloaded from Tectonic account
 * `tectonic_pull_secret_path` - Full path to `config.json` container pull secret file downloaded from Tectonic account

--- a/Documentation/tutorials/azure/install.md
+++ b/Documentation/tutorials/azure/install.md
@@ -152,7 +152,7 @@ $ cd tectonic
 
 ### Create a cluster build directory
 
-Choose a cluster name to identify the cluster. Export an environment variable with the chosen cluster name. In this tutorial, `my-cluster` is used.
+Choose a cluster name to identify the cluster. Export an environment variable with the chosen cluster name. This tutorial names the cluster `my-cluster`.
 
 ```
 $ export CLUSTER=my-cluster
@@ -165,17 +165,34 @@ $ mkdir -p build/${CLUSTER}
 $ cp examples/terraform.tfvars.azure build/${CLUSTER}/terraform.tfvars
 ```
 
-Edit the parameters in `build/$CLUSTER/terraform.tfvars` with the deployment's Azure details, domain name, license, and pull secret. [View all of the Azure specific options][azure-vars] and [the common Tectonic variables][vars].
-
 ### Key values for basic Azure deployment
 
-These are the basic values that must be adjusted for each Tectonic deployment on Azure. See the details of each value in the comments in the `terraform.tfvars` file.
+These are the basic values that must be adjusted for each Tectonic deployment on Azure.
 
-* `tectonic_admin_email` - For the initial Console login
-* `tectonic_admin_password_hash` - Use [`bcrypt-tool`][bcrypt-tool] to encrypt password
-* `tectonic_azure_client_secret` - As in `ARM_CLIENT_SECRET` above
+#### Environment variables
+
+Set these sensitive values in the environment. Terraform will encrypt them before storage or transport:
+
+* `TF_VAR_tectonic_admin_email` - String giving the email address used as user name for the initial Console login
+* `TF_VAR_tectonic_admin_password` - Plaintext password string for initial Console login
+* `TF_VAR_tectonic_azure_client_secret` - Generated, obfuscated password string matching `ARM_CLIENT_SECRET` and `password` value from `az ad` output, above
+* `TF_VAR_tectonic_azure_location` - Lowercase catenated string giving the Azure location name (example: `centralus`)
+
+For example, in the `bash(1)` shell, replace the quoted values with those for the cluster being deployed and run the following commands:
+
+```bash
+$ export TF_VAR_tectonic_admin_email="admin@example.com"
+$ export TF_VAR_tectonic_admin_password="pl41nT3xt"
+$ export TF_VAR_tectonic_azure_client_secret=${ARM_CLIENT_SECRET}
+$ export TF_VAR_tectonic_azure_location="centralus"
+...
+```
+
+#### Terraform variables file
+
+Edit the parameters in `build/$CLUSTER/terraform.tfvars` with the deployment's Azure details, domain name, license, and pull secret. See the details of each value below in the [terraform.tfvars][terraform-tvars] file, or check the complete list of [Azure specific options][azure-vars] and [the common Tectonic variables][vars].
+
 * `tectonic_azure_ssh_key` - Full path to the public key part of the key added to `ssh-agent` above
-* `tectonic_azure_location` - e.g., `centralus`
 * `tectonic_base_domain` - The DNS domain or subdomain delegated to an Azure DNS zone above
 * `tectonic_azure_external_dns_zone_id` - Value of `id` in `az network dns zone list` output
 * `tectonic_cluster_name` - Usually matches `$CLUSTER` as set above


### PR DESCRIPTION
Change Azure install and tutorial doc to place deploy-time secrets
in the shell env rather than in tf config file.

Ref:
https://github.com/coreos/tectonic-installer/pull/2327
https://jira.prod.coreos.systems/browse/TECREL-126
https://jira.prod.coreos.systems/browse/DOCS-209