### PR TITLE
install/*/*-terraform.md: Put Console secrets in environment

### DIFF
--- a/Documentation/install/aws/aws-terraform.md
+++ b/Documentation/install/aws/aws-terraform.md
@@ -111,6 +111,20 @@ $ cp examples/terraform.tfvars.aws build/${CLUSTER}/terraform.tfvars
 
 Edit the parameters with your AWS details, domain name, license, etc. [View all of the AWS specific options][aws-vars] and [the common Tectonic variables][vars].
 
+### Set Console login secrets
+
+Set these sensitive values in the environment. The `tectonic_admin_password` will be encrypted before storage or transport:
+
+* `TF_VAR_tectonic_admin_email` - String giving the email address used as user name for the initial Console login
+* `TF_VAR_tectonic_admin_password` - Plaintext password string for initial Console login
+
+For example, in the `bash(1)` shell, replace the quoted values with those for the cluster being deployed and run the following commands:
+
+```bash
+$ export TF_VAR_tectonic_admin_email="admin@example.com"
+$ export TF_VAR_tectonic_admin_password="pl41nT3xt"
+```
+
 ## Deploy the cluster
 
 Test out the plan before deploying everything:

--- a/Documentation/install/azure/azure-terraform.md
+++ b/Documentation/install/azure/azure-terraform.md
@@ -184,7 +184,7 @@ These are the basic values that must be adjusted for each Tectonic deployment on
 
 #### Environment variables
 
-Set these sensitive values in the environment. Terraform will encrypt them before storage or transport:
+Set these sensitive values in the environment. The `tectonic_admin_password` will be encrypted before storage or transport:
 
 * `TF_VAR_tectonic_admin_email` - String giving the email address used as user name for the initial Console login
 * `TF_VAR_tectonic_admin_password` - Plaintext password string for initial Console login

--- a/Documentation/install/bare-metal/metal-terraform.md
+++ b/Documentation/install/bare-metal/metal-terraform.md
@@ -113,6 +113,20 @@ Several variables are currently required, but their values are not used.
 * `tectonic_worker_count`
 * `tectonic_etcd_count`
 
+### Set Console login secrets
+
+Set these sensitive values in the environment. The `tectonic_admin_password` will be encrypted before storage or transport:
+
+* `TF_VAR_tectonic_admin_email` - String giving the email address used as user name for the initial Console login
+* `TF_VAR_tectonic_admin_password` - Plaintext password string for initial Console login
+
+For example, in the `bash(1)` shell, replace the quoted values with those for the cluster being deployed and run the following commands:
+
+```bash
+$ export TF_VAR_tectonic_admin_email="admin@example.com"
+$ export TF_VAR_tectonic_admin_password="pl41nT3xt"
+```
+
 ## Deploy the cluster
 
 Test out the plan before deploying everything:

--- a/Documentation/install/openstack/openstack-terraform.md
+++ b/Documentation/install/openstack/openstack-terraform.md
@@ -135,6 +135,20 @@ $ cp examples/terraform.tfvars.openstack-neutron build/${CLUSTER}/terraform.tfva
 
 Edit the parameters with your OpenStack details. View all of the [OpenStack Neutron][openstack-neutron-vars] specific options and [the common Tectonic variables][vars].
 
+### Set Console login secrets
+
+Set these sensitive values in the environment. The `tectonic_admin_password` will be encrypted before storage or transport:
+
+* `TF_VAR_tectonic_admin_email` - String giving the email address used as user name for the initial Console login
+* `TF_VAR_tectonic_admin_password` - Plaintext password string for initial Console login
+
+For example, in the `bash(1)` shell, replace the quoted values with those for the cluster being deployed and run the following commands:
+
+```bash
+$ export TF_VAR_tectonic_admin_email="admin@example.com"
+$ export TF_VAR_tectonic_admin_password="pl41nT3xt"
+```
+
 ## Deploy the cluster
 
 Test out the plan before deploying everything:

--- a/Documentation/install/vmware/vmware-terraform.md
+++ b/Documentation/install/vmware/vmware-terraform.md
@@ -115,6 +115,20 @@ $ cd build/${CLUSTER}/
 
 Edit the parameters with details of the VMware infrastructure. View all of the [VMware][vmware] specific options and [the common Tectonic variables][vars].
 
+### Set Console login secrets
+
+Set these sensitive values in the environment. The `tectonic_admin_password` will be encrypted before storage or transport:
+
+* `TF_VAR_tectonic_admin_email` - String giving the email address used as user name for the initial Console login
+* `TF_VAR_tectonic_admin_password` - Plaintext password string for initial Console login
+
+For example, in the `bash(1)` shell, replace the quoted values with those for the cluster being deployed and run the following commands:
+
+```bash
+$ export TF_VAR_tectonic_admin_email="admin@example.com"
+$ export TF_VAR_tectonic_admin_password="pl41nT3xt"
+```
+
 ## Deploy the cluster
 
 Download the Tectonic Terraform modules:

--- a/Documentation/tutorials/azure/install.md
+++ b/Documentation/tutorials/azure/install.md
@@ -171,7 +171,7 @@ These are the basic values that must be adjusted for each Tectonic deployment on
 
 #### Environment variables
 
-Set these sensitive values in the environment. Terraform will encrypt them before storage or transport:
+Set these sensitive values in the environment. The `tectonic_admin_password` will be encrypted before storage or transport:
 
 * `TF_VAR_tectonic_admin_email` - String giving the email address used as user name for the initial Console login
 * `TF_VAR_tectonic_admin_password` - Plaintext password string for initial Console login


### PR DESCRIPTION
For providers other than Azure, change docs to put Console user
name and password in environment. These platforms either do not have
or already store other secrets like region/loc, cloud client key, etc
in the environment.

Ref:
https://github.com/coreos/tectonic-installer/pull/2327
https://github.com/coreos/tectonic-docs/pull/92
https://jira.prod.coreos.systems/browse/TECREL-126
https://jira.prod.coreos.systems/browse/DOCS-209