### PR TITLE
Documentation: Fix broken links

### DIFF
--- a/Documentation/admin/assets-zip.md
+++ b/Documentation/admin/assets-zip.md
@@ -35,4 +35,4 @@ kubectl patch deployment tectonic-identity \
 
 Administrators should take proper precautions to ensure these assets remain secure.
 
-[tectonic-identity]: user-management.md
+[tectonic-identity]: ../users/tectonic-identity-config.md

--- a/Documentation/admin/identity-management.md
+++ b/Documentation/admin/identity-management.md
@@ -93,8 +93,8 @@ The default Cluster-wide roles in tectonic are:
 | view      | Read only view for all objects. Can be used cluster-wide, or just within a specific namespace.|
 
 
-[user-management]: user-management.md
-[ldap-user-management]: ldap-user-management.md
-[saml-user-management]: saml-user-management.md
+[user-management]: ../users/tectonic-identity-config.md
+[ldap-user-management]: ../users/ldap-integration.md
+[saml-user-management]: ../users/saml-integration.md
 [dex]: https://github.com/coreos/dex
 [third-party]: https://github.com/coreos/dex/blob/master/Documentation/storage.md#Kubernetes-third-party-resources

--- a/Documentation/admin/index.md
+++ b/Documentation/admin/index.md
@@ -7,6 +7,6 @@
 
 
 [admin-upgrade]: upgrade.md
-[admin-user-management]: user-management.md
+[admin-user-management]: ../users/tectonic-identity-config.md
 [assets-zip]: assets-zip.md
 [logging]: logging.md

--- a/Documentation/admin/ingress.md
+++ b/Documentation/admin/ingress.md
@@ -159,7 +159,7 @@ For more information, see the nginx documentation on the [large-client-header-bu
 
 
 [ingress-userguide]: https://kubernetes.io/docs/user-guide/ingress/
-[service-accounts]: onboard-service-account.md
-[controller-deployments]: https://github.com/kubernetes/ingress/tree/master/examples/deployment
+[service-accounts]: ../users/creating-service-accounts.md
+[controller-deployments]: https://github.com/kubernetes/ingress-nginx/tree/master/deploy
 [nginx-ingress]: https://github.com/kubernetes/ingress/tree/master/controllers/nginx
 [large-flag]: http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers

--- a/Documentation/admin/manage-namespaces.md
+++ b/Documentation/admin/manage-namespaces.md
@@ -50,5 +50,5 @@ Check out the [Kubernetes Namespace User Guide][k8s-namespace-ug] for more infor
 
 [k8s-namespace-ug]: https://kubernetes.io/docs/admin/namespaces/
 [namespaces-default]: ../img/walkthrough/namespaces-default.png
-[user-mgmt]: ../admin/user-management.md
+[user-mgmt]: ../users/tectonic-identity-config.md
 [k8s-rbac]: https://kubernetes.io/docs/admin/authorization/#rbac-mode

--- a/Documentation/troubleshooting/faq.md
+++ b/Documentation/troubleshooting/faq.md
@@ -61,6 +61,6 @@ Make sure to check out the [community support forum](https://github.com/coreos/t
 
 
 [assets]: ../admin/assets-zip.md
-[user-management]: ../admin/user-management.md
+[user-management]: ../users/tectonic-identity-config.md
 [contact]: https://coreos.com/contact/
 [sign-up]: https://account.coreos.com/signup/summary/tectonic-2016-12

--- a/Documentation/tutorials/azure/install.md
+++ b/Documentation/tutorials/azure/install.md
@@ -190,7 +190,7 @@ $ export TF_VAR_tectonic_azure_location="centralus"
 
 #### Terraform variables file
 
-Edit the parameters in `build/$CLUSTER/terraform.tfvars` with the deployment's Azure details, domain name, license, and pull secret. See the details of each value below in the [terraform.tfvars][terraform-tvars] file, or check the complete list of [Azure specific options][azure-vars] and [the common Tectonic variables][vars].
+Edit the parameters in `build/$CLUSTER/terraform.tfvars` with the deployment's Azure details, domain name, license, and pull secret. See the details of each value in the cluster's `terraform.tfvars`  file, or check the complete list of [Azure specific options][azure-vars] and [the common Tectonic variables][vars].
 
 * `tectonic_azure_ssh_key` - Full path to the public key part of the key added to `ssh-agent` above
 * `tectonic_base_domain` - The DNS domain or subdomain delegated to an Azure DNS zone above

--- a/Documentation/users/creating-accounts.md
+++ b/Documentation/users/creating-accounts.md
@@ -119,4 +119,4 @@ For more information see the [Kubernetes RBAC documentation][k8s-rbac].
 [ldap-integration]: ldap-integration.md
 [saml-integration]: saml-integration.md
 [user-facing]: https://kubernetes.io/docs/admin/authorization/rbac/#user-facing-roles
-[default-roles]: creating-roles.md/#default-roles-in-tectonic
+[default-roles]: creating-roles.md#default-roles-in-tectonic

--- a/Documentation/users/creating-roles.md
+++ b/Documentation/users/creating-roles.md
@@ -55,9 +55,8 @@ For more information on these roles, see [User-facing Roles][user-facing] in the
 
 ## Assign Users to Roles
 
-To grant users access to Roles, [use a Role Binding][creating-role-bindings].
+To grant users access to Roles, [use a Role Binding][role-binding].
 
 
 [role-binding]: creating-accounts.md#creating-role-bindings
 [user-facing]: https://kubernetes.io/docs/admin/authorization/rbac/#user-facing-roles
-[creating-role-bindings]: creating-accounts.md/#creating-role-bindings


### PR DESCRIPTION
Fix a handful of broken links found with marker.

Relates to redirects added in https://github.com/coreos-inc/coreos-pages-deploy/pull/14 for Identity docs reorganization.