### PR TITLE
Extend name for expanded installer directory

### DIFF
--- a/Documentation/install/aws/aws-terraform.md
+++ b/Documentation/install/aws/aws-terraform.md
@@ -46,7 +46,7 @@ Extract the tarball and navigate to the `tectonic` directory.
 
 ```bash
 $ tar xzvf tectonic_1.7.9-tectonic.1.tar.gz
-$ cd tectonic
+$ cd tectonic_1.7.9-tectonic.1
 ```
 
 ### Initialize and configure Terraform

--- a/Documentation/install/aws/index.md
+++ b/Documentation/install/aws/index.md
@@ -31,7 +31,7 @@ Download the [Tectonic installer][latest-tectonic-release].
 ```bash
 wget https://releases.tectonic.com/releases/tectonic_1.7.9-tectonic.1.tar.gz
 tar xzvf tectonic_1.7.9-tectonic.1.tar.gz
-cd tectonic
+cd tectonic_1.7.9-tectonic.1
 ```
 
 Run the Tectonic Installer for your platform.

--- a/Documentation/install/aws/uninstall.md
+++ b/Documentation/install/aws/uninstall.md
@@ -26,7 +26,7 @@ Next, navigate to the cluster state directory written to the extracted `tectonic
 ```bash
 # Replace <os> with darwin or linux
 # Replace <CLUSTERNAME> with a string like mytectonic_2017-05-03_11-41-02
-$ cd tectonic/tectonic-installer/<os>/clusters/<CLUSTERNAME>
+$ cd tectonic_1.7.9-tectonic.1/tectonic-installer/<os>/clusters/<CLUSTERNAME>
 $ export PATH=$(pwd)/../..:$PATH	# Add Installer's terraform binary to PATH
 ```
 

--- a/Documentation/install/azure/azure-terraform.md
+++ b/Documentation/install/azure/azure-terraform.md
@@ -89,7 +89,7 @@ Extract the tarball and navigate to the `tectonic` directory.
 
 ```bash
 $ tar xzvf tectonic_1.7.9-tectonic.1.tar.gz
-$ cd tectonic
+$ cd tectonic_1.7.9-tectonic.1
 ```
 
 ### Initialize and configure Terraform

--- a/Documentation/install/bare-metal/index.md
+++ b/Documentation/install/bare-metal/index.md
@@ -172,7 +172,7 @@ Download [Tectonic Installer][latest-tectonic-release].
 ```sh
 wget https://releases.tectonic.com/releases/tectonic_1.7.9-tectonic.1.tar.gz
 tar xzvf tectonic_1.7.9-tectonic.1.tar.gz
-cd tectonic/tectonic-installer
+cd tectonic_1.7.9-tectonic.1/tectonic-installer
 ```
 
 Run the Tectonic Installer for your platform:

--- a/Documentation/install/bare-metal/metal-terraform.md
+++ b/Documentation/install/bare-metal/metal-terraform.md
@@ -50,7 +50,7 @@ Extract the tarball and navigate to the `tectonic` directory.
 
 ```bash
 $ tar xzvf tectonic_1.7.9-tectonic.1.tar.gz
-$ cd tectonic
+$ cd tectonic_1.7.9-tectonic.1
 ```
 
 ### Initialize and configure Terraform

--- a/Documentation/install/openstack/openstack-terraform.md
+++ b/Documentation/install/openstack/openstack-terraform.md
@@ -52,7 +52,7 @@ Extract the tarball and navigate to the `tectonic` directory.
 
 ```bash
 $ tar xzvf tectonic_1.7.9-tectonic.1.tar.gz
-$ cd tectonic
+$ cd tectonic_1.7.9-tectonic.1
 ```
 
 ### Initialize and configure Terraform

--- a/Documentation/install/vmware/vmware-terraform.md
+++ b/Documentation/install/vmware/vmware-terraform.md
@@ -94,7 +94,7 @@ Extract the tarball and navigate to the `tectonic` directory.
 
 ```bash
 $ tar xzvf tectonic_1.7.9-tectonic.1.tar.gz
-$ cd tectonic
+$ cd tectonic_1.7.9-tectonic.1
 ```
 
 ## Customize the deployment

--- a/Documentation/tutorials/aws/installing-tectonic.md
+++ b/Documentation/tutorials/aws/installing-tectonic.md
@@ -63,7 +63,7 @@ When prompted, log in to your CoreOS account to obtain the License and Pull Secr
 If you prefer to work within the terminal, extract and launch the Installer using:
 ```bash
 tar xzvf tectonic_1.7.9-tectonic.1.tar.gz # to extract the tarball
-$ cd tectonic/tectonic-installer # to change to the previously untarred directory
+$ cd tectonic_1.7.9-tectonic.1/tectonic-installer # to change to the previously untarred directory
 $ ./$PLATFORM/installer # to run Tectonic Installer
 ```
 Where `$PLATFORM` is `linux` or `darwin`.

--- a/Documentation/tutorials/azure/install.md
+++ b/Documentation/tutorials/azure/install.md
@@ -147,7 +147,7 @@ Extract the tarball and navigate to the `tectonic` directory.
 
 ```bash
 $ tar xzvf tectonic_1.7.9-tectonic.1.tar.gz
-$ cd tectonic
+$ cd tectonic_1.7.9-tectonic.1
 ```
 
 ### Create a cluster build directory


### PR DESCRIPTION
The installer download now expands to a
directory named
tectonic_$k8svers-tectonic.$tectonicvers
-- eg., tectonic_1.7.9-tectonic.1/

(this is the master proposed change; cherry pick from here to a new 1.7.9 tag before resync in -pages)