### PR TITLE
troubleshooting: add calico upgrade guide

### DIFF
--- a/Documentation/troubleshooting/calico-manifests/calico-upgrade-job.yaml
+++ b/Documentation/troubleshooting/calico-manifests/calico-upgrade-job.yaml
@@ -1,0 +1,106 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-25-migration
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs:
+      - create
+      - get
+      - list
+      - post
+      - patch
+      - update
+      - watch
+  - apiGroups: ["extensions"]
+    resources:
+      - thirdpartyresources
+    verbs:
+      - create
+      - get
+      - list
+      - post
+      - patch
+      - update
+      - watch
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+      - get
+      - list
+      - post
+      - patch
+      - update
+      - watch
+  - apiGroups: ["projectcalico.org"]
+    resources:
+      - globalbgppeers
+      - globalconfigs
+      - globalbgpconfigs
+      - ippools
+    verbs:
+      - create
+      - get
+      - list
+      - post
+      - patch
+      - update
+      - watch
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - globalfelixconfigs
+      - bgppeers
+      - globalbgpconfigs
+      - ippools
+      - globalnetworkpolicies
+    verbs:
+      - create
+      - get
+      - list
+      - post
+      - patch
+      - update
+      - watch
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-25-migration
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-25-migration
+subjects:
+ - kind: ServiceAccount
+   name: calico-25-migration
+   namespace: default
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-25-migration
+
+---
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: calico-upgrade-v2.5
+spec:
+  template:
+    metadata:
+      name: calico-upgrade-v2.5
+    spec:
+      serviceAccountName: calico-25-migration
+      containers:
+      - name: calico-upgrade
+        image: calico/v2.5-upgrade:v0.0.1
+      restartPolicy: Never

--- a/Documentation/troubleshooting/calico-manifests/rbac-canal-tectonic-18.yaml
+++ b/Documentation/troubleshooting/calico-manifests/rbac-canal-tectonic-18.yaml
@@ -1,0 +1,54 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kube-calico
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: [""]
+    resources:
+      - pods/status
+    verbs:
+      - update
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups: ["extensions"]
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - globalfelixconfigs
+      - bgppeers
+      - globalbgpconfigs
+      - ippools
+      - globalnetworkpolicies
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - watch

--- a/Documentation/troubleshooting/tectonic-upgrade.md
+++ b/Documentation/troubleshooting/tectonic-upgrade.md
@@ -6,7 +6,9 @@ This document describes how to troubleshoot issues encountered when upgrading to
 
 To update to 1.8.4-tectonic.1, first update to 1.7.9-tectonic.3. Ensure that all Third Party Resources (TPRs) have been removed from the cluster, as compatibility was removed in Kubernetes 1.8..
 
-If you participated in the Calico Network Security Policy or BGP routing alpha programs, please follow [the manual steps][calico-upgrade] to migrate your TPRs to CRDs. After the alpha program concludes, migrations like this will be handled via Automated Operations without any user intervention.
+If you participated in the Calico Network Security Policy alpha program, please follow [the manual steps][calico-upgrade] to migrate your TPRs to CRDs. After the alpha program concludes, migrations like this will be handled via Automated Operations without any user intervention.
+
+Once you are running `1.7.9-tectonic.3`, simply change the update channel to `Tectonic-1.8-preproduction` or `Tectonic-1.8-production` channel and click "Check for Update".
 
 ## Upgrading StatefulSets
 

--- a/Documentation/troubleshooting/tectonic-upgrade.md
+++ b/Documentation/troubleshooting/tectonic-upgrade.md
@@ -58,4 +58,4 @@ Then, use Tectonic Console to switch the channel back to `Tectonic-1.6`. Click `
 
 After upgrading to `1.6.7-tectonic.2`, switch to the `Tectonic-1.7` channel and upgrade from there.
 
-[calico-upgrade]: upgrading-calico.md
+[calico-upgrade]: upgrade-calico.md

--- a/Documentation/troubleshooting/tectonic-upgrade.md
+++ b/Documentation/troubleshooting/tectonic-upgrade.md
@@ -1,6 +1,12 @@
 # Troubleshooting Tectonic upgrades
 
-This document describes how to troubleshoot issues encountered when upgrading to Tectonic versions 1.7.1-tectonic.1 or greater.
+This document describes how to troubleshoot issues encountered when upgrading to specific Tectonic versions.
+
+## Upgrading to 1.8.4-tectonic.1
+
+To update to 1.8.4-tectonic.1, first update to 1.7.9-tectonic.3. Ensure that all Third Party Resources (TPRs) have been removed from the cluster, as compatibility was removed in Kubernetes 1.8..
+
+If you participated in the Calico Network Security Policy or BGP routing alpha programs, please follow [the manual steps][calico-upgrade] to migrate your TPRs to CRDs. After the alpha program concludes, migrations like this will be handled via Automated Operations without any user intervention.
 
 ## Upgrading StatefulSets
 
@@ -51,3 +57,5 @@ EOF
 Then, use Tectonic Console to switch the channel back to `Tectonic-1.6`. Click `Check for Updates`, then click `Start Upgrade`.
 
 After upgrading to `1.6.7-tectonic.2`, switch to the `Tectonic-1.7` channel and upgrade from there.
+
+[calico-upgrade]: upgrading-calico.md

--- a/Documentation/troubleshooting/upgrade-calico.md
+++ b/Documentation/troubleshooting/upgrade-calico.md
@@ -1,0 +1,89 @@
+# Upgrading Calico Manually
+
+Tectonic included alpha support for Network Security Policy and BGP routing functionality in 1.7.x releases, powered by Calico.
+
+Under the hook, Calico utilized Third Party Resources (TPRs) for configuration. These TPRs need to be upgraded to Custom Resource Definitions (CRDs) before upgrading to 1.8.x. This process is automated, but must be started manually.
+
+After the alpha period, upgrades to Tectonic's network functionality will be fully supported by Tectonic's trademark Automated Operations.
+
+## Back up TPRs
+
+As with all upgrades, start by backing up your TPRs:
+
+```
+$ kubectl get globalconfig --all-namespaces --export -o yaml > global-configs.yaml
+$ kubectl get ippool --all-namespaces --export -o yaml > ip-pools.yaml
+$ kubectl get systemnetworkpolicy.alpha --all-namespaces --export -o yaml > system-network-policies.yaml
+```
+
+## Run the migration Job
+
+An automated migration is run as a Kubernetes Job. [Download the Job object][download-job] and create it in the `default` namespace:
+
+```
+$ kubectl -n default apply -f upgrade-job.yaml
+```
+
+You can check the status of the Job and it's output logs:
+
+```
+$ kubectl describe job/calico-upgrade-v2.5
+```
+
+After the job is complete, verify that new data exists as CRDs:
+
+```
+$ kubectl get ippools.crd.projectcalico.org
+$ kubectl get globalfelixconfigs.crd.projectcalico.org
+```
+
+## Upgrade the Role Based Access Control rules
+
+[Download the new RBAC rule][download-rules] which adds access to manipulate the new CRD types:
+
+```
+$ kubectl -n kube-system apply -f rbac-canal-tectonic-18.yaml
+```
+
+## Perform the rolling update
+
+First, update the images to reference the new Calcio version:
+
+```
+$ kubectl -n kube-system set image daemonset/kube-calico kube-calico=quay.io/calico/node:v2.6.1 \
+    install-cni=quay.io/calico/cni:v1.11.0
+```
+
+Watch progress of the update process:
+
+```
+$ kubectl -n kube-system get pods | grep calico
+```
+
+## Verify the update
+
+To verify the process went smoothly, check that a Pod can be started on the cluster:
+
+```
+$ kubectl run --rm -i --tty busybox --image=busybox
+```
+
+## Clean up
+
+Clean up the unneeded TPRs and the upgrade job:
+
+```
+$ kubectl delete thirdpartyresources/global-bgp-config.projectcalico.org
+$ kubectl delete thirdpartyresources/global-bgp-peer.projectcalico.org
+$ kubectl delete thirdpartyresources/global-config.projectcalico.org
+$ kubectl delete thirdpartyresources/ip-pool.projectcalico.org
+$ kubectl delete thirdpartyresources/system-network-policy.alpha.projectcalico.org
+$ kubectl delete -f upgrade-job.yaml
+```
+
+## Proceed with your Tectonic upgrade
+
+This process ensures that TPRs utilized by Calcio are removed. If you are using other TPRs, remove or migrate them before attempting to upgrade to Tectonic 1.8.
+
+[download-rules]: calico-manifests/rbac-canal-tectonic-18.yaml
+[download-job]: calico-manifests/calico-upgrade-job.yaml

--- a/Documentation/troubleshooting/upgrade-calico.md
+++ b/Documentation/troubleshooting/upgrade-calico.md
@@ -1,6 +1,6 @@
 # Upgrading Calico Manually
 
-Tectonic included alpha support for Network Security Policy and BGP routing functionality in 1.7.x releases, powered by Calico.
+Tectonic included alpha support for Network Security Policy functionality in 1.7.x releases, powered by Calico.
 
 Under the hook, Calico utilized Third Party Resources (TPRs) for configuration. These TPRs need to be upgraded to Custom Resource Definitions (CRDs) before upgrading to 1.8.x. This process is automated, but must be started manually.
 

--- a/Documentation/troubleshooting/upgrade-calico.md
+++ b/Documentation/troubleshooting/upgrade-calico.md
@@ -83,7 +83,7 @@ $ kubectl delete -f upgrade-job.yaml
 
 ## Proceed with your Tectonic upgrade
 
-This process ensures that TPRs utilized by Calcio are removed. If you are using other TPRs, remove or migrate them before attempting to upgrade to Tectonic 1.8.
+This process ensures that TPRs utilized by Calico are removed. If you are using other TPRs, remove or migrate them before attempting to upgrade to Tectonic 1.8.
 
 [download-rules]: calico-manifests/rbac-canal-tectonic-18.yaml
 [download-job]: calico-manifests/calico-upgrade-job.yaml

--- a/Documentation/troubleshooting/upgrade-calico.md
+++ b/Documentation/troubleshooting/upgrade-calico.md
@@ -2,7 +2,7 @@
 
 Tectonic included alpha support for Network Security Policy functionality in 1.7.x releases, powered by Calico.
 
-Under the hook, Calico utilized Third Party Resources (TPRs) for configuration. These TPRs need to be upgraded to Custom Resource Definitions (CRDs) before upgrading to 1.8.x. This process is automated, but must be started manually.
+Under the hood, Calico utilized Third Party Resources (TPRs) for configuration. These TPRs must be upgraded to be upgraded to Custom Resource Definitions (CRDs) before upgrading to 1.8.x. This process is automated, but must be manually started.
 
 After the alpha period, upgrades to Tectonic's network functionality will be fully supported by Tectonic's trademark Automated Operations.
 
@@ -24,7 +24,7 @@ An automated migration is run as a Kubernetes Job. [Download the Job object][dow
 $ kubectl -n default apply -f upgrade-job.yaml
 ```
 
-You can check the status of the Job and it's output logs:
+Check the status of the Job and its output logs:
 
 ```
 $ kubectl describe job/calico-upgrade-v2.5
@@ -37,7 +37,7 @@ $ kubectl get ippools.crd.projectcalico.org
 $ kubectl get globalfelixconfigs.crd.projectcalico.org
 ```
 
-## Upgrade the Role Based Access Control rules
+## Upgrade the Role-Based Access Control rules
 
 [Download the new RBAC rule][download-rules] which adds access to manipulate the new CRD types:
 
@@ -47,7 +47,7 @@ $ kubectl -n kube-system apply -f rbac-canal-tectonic-18.yaml
 
 ## Perform the rolling update
 
-First, update the images to reference the new Calcio version:
+First, update the images to reference the new Calico version:
 
 ```
 $ kubectl -n kube-system set image daemonset/kube-calico kube-calico=quay.io/calico/node:v2.6.1 \


### PR DESCRIPTION
Adds manifests for the updated RBAC rules and the migration job.

We can link to this from the release notes.