### PR TITLE
docs/aws: add new permission to the policy due new aws terraform provider v1.7.0

### DIFF
--- a/Documentation/files/aws-policy.json
+++ b/Documentation/files/aws-policy.json
@@ -141,6 +141,7 @@
                 "s3:GetBucketWebsite",
                 "s3:GetBucketVersioning",
                 "s3:GetAccelerateConfiguration",
+                "s3:GetEncryptionConfiguration",
                 "s3:GetBucketRequestPayment",
                 "s3:GetBucketLogging",
                 "s3:GetLifecycleConfiguration",


### PR DESCRIPTION
fixes: https://jira.coreos.com/browse/INST-855.

We update the terraform aws provider to version 1.7.0 and in this new release terraform need this permission (`s3:GetEncryptionConfiguration`)  to validate if the bucket has any encryption configurated.