### PR TITLE
Update version strings for 1.7.14

### DIFF
--- a/Documentation/hack/centos-workers.md
+++ b/Documentation/hack/centos-workers.md
@@ -6,7 +6,7 @@ This is unofficial. The author does not update, maintain, or support this setup.
 
 ## CoreOS Tectonic
 
-Provision a Tectonic `1.8.7-tectonic.2` bare-metal cluster (Container Linux, 1 controller, 2 workers) in the usual way with [matchbox](https://github.com/coreos/matchbox) and the Tectonic [Installer](https://coreos.com/tectonic/docs/latest/install/bare-metal/index.html).
+Provision a Tectonic `1.7.14-tectonic.1` bare-metal cluster (Container Linux, 1 controller, 2 workers) in the usual way with [matchbox](https://github.com/coreos/matchbox) and the Tectonic [Installer](https://coreos.com/tectonic/docs/latest/install/bare-metal/index.html).
 
 Locally, you may PXE boot QEMU/KVM nodes via Tectonic and matchbox on the `metal0` bridge.
 

--- a/Documentation/install/aws/aws-terraform.md
+++ b/Documentation/install/aws/aws-terraform.md
@@ -41,23 +41,23 @@ Once the update has processed, the *Overview* window will refresh to include lin
 Open a new terminal and run the following command to download Tectonic Installer.
 
 ```bash
-$ curl -O https://releases.tectonic.com/releases/tectonic_1.8.7-tectonic.2.zip
-$ curl -O https://releases.tectonic.com/releases/tectonic_1.8.7-tectonic.2.zip.sig
+$ curl -O https://releases.tectonic.com/releases/tectonic_1.7.14-tectonic.1.zip
+$ curl -O https://releases.tectonic.com/releases/tectonic_1.7.14-tectonic.1.zip.sig
 ```
 
 Verify the release has been signed by the [CoreOS App Signing Key][verification-key].
 
 ```bash
 $ gpg2 --keyserver pgp.mit.edu --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
-$ gpg2 --verify tectonic_1.8.7-tectonic.2.zip.sig tectonic_1.8.7-tectonic.2.zip
+$ gpg2 --verify tectonic_1.7.14-tectonic.1.zip.sig tectonic_1.7.14-tectonic.1.zip
 # gpg2: Good signature from "CoreOS Application Signing Key <security@coreos.com>"
 ```
 
 Unzip Tectonic Installer and navigate to the `tectonic` directory.
 
 ```bash
-$ unzip tectonic_1.8.7-tectonic.2.zip
-$ cd tectonic_1.8.7-tectonic.2
+$ unzip tectonic_1.7.14-tectonic.1.zip
+$ cd tectonic_1.7.14-tectonic.1
 ```
 
 ### Initialize and configure Terraform

--- a/Documentation/install/aws/index.md
+++ b/Documentation/install/aws/index.md
@@ -29,9 +29,9 @@ Make sure a current version of either Google Chrome or Mozilla Firefox is set as
 Download the [Tectonic installer][latest-tectonic-release].
 
 ```bash
-wget https://releases.tectonic.com/releases/tectonic_1.8.7-tectonic.2.zip
-unzip tectonic_1.8.7-tectonic.2.zip
-cd tectonic_1.8.7-tectonic.2
+wget https://releases.tectonic.com/releases/tectonic_1.7.14-tectonic.1.zip
+unzip tectonic_1.7.14-tectonic.1.zip
+cd tectonic_1.7.14-tectonic.1
 ```
 
 Run the Tectonic Installer for your platform.
@@ -94,7 +94,7 @@ For those new to Tectonic and Kubernetes, the [Tectonic Tutorials][tutorials] pr
 [install-aws-requirements-creds]: requirements.md#privileges
 [install-aws-requirements-evpc]: requirements.md#using-an-existing-vpc
 [tutorials]: ../../tutorials/index.md
-[latest-tectonic-release]: https://releases.tectonic.com/releases/tectonic_1.8.7-tectonic.2.zip
+[latest-tectonic-release]: https://releases.tectonic.com/releases/tectonic_1.7.14-tectonic.1.zip
 [install-aws-troubleshooting]: ../../troubleshooting/faq.md
 [tf-state]: https://www.terraform.io/docs/state/
 [install-windows]: ../installer-windows.md

--- a/Documentation/install/aws/uninstall.md
+++ b/Documentation/install/aws/uninstall.md
@@ -26,7 +26,7 @@ Next, navigate to the cluster state directory written to the extracted `tectonic
 ```bash
 # Replace <os> with darwin or linux
 # Replace <CLUSTERNAME> with a string like mytectonic_2017-05-03_11-41-02
-$ cd tectonic_1.8.7-tectonic.2/tectonic-installer/<os>/clusters/<CLUSTERNAME>
+$ cd tectonic_1.7.14-tectonic.1/tectonic-installer/<os>/clusters/<CLUSTERNAME>
 $ export PATH=$(pwd)/../..:$PATH	# Add Installer's terraform binary to PATH
 ```
 

--- a/Documentation/install/azure/azure-terraform.md
+++ b/Documentation/install/azure/azure-terraform.md
@@ -73,23 +73,23 @@ Also ensure the SSH known_hosts file doesn't have old records for the API DNS na
 Open a new terminal and run the following command to download Tectonic Installer.
 
 ```bash
-$ curl -O https://releases.tectonic.com/releases/tectonic_1.8.7-tectonic.2.zip
-$ curl -O https://releases.tectonic.com/releases/tectonic_1.8.7-tectonic.2.zip.sig
+$ curl -O https://releases.tectonic.com/releases/tectonic_1.7.14-tectonic.1.zip
+$ curl -O https://releases.tectonic.com/releases/tectonic_1.7.14-tectonic.1.zip.sig
 ```
 
 Verify the release has been signed by the [CoreOS App Signing Key][verification-key].
 
 ```bash
 $ gpg2 --keyserver pgp.mit.edu --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
-$ gpg2 --verify tectonic_1.8.7-tectonic.2.zip.sig tectonic_1.8.7-tectonic.2.zip
+$ gpg2 --verify tectonic_1.7.14-tectonic.1.zip.sig tectonic_1.7.14-tectonic.1.zip
 # gpg2: Good signature from "CoreOS Application Signing Key <security@coreos.com>"
 ```
 
 Unzip Tectonic Installer and navigate to the `tectonic` directory.
 
 ```bash
-$ unzip tectonic_1.8.7-tectonic.2.zip
-$ cd tectonic_1.8.7-tectonic.2
+$ unzip tectonic_1.7.14-tectonic.1.zip
+$ cd tectonic_1.7.14-tectonic.1
 ```
 
 ### Initialize and configure Terraform

--- a/Documentation/install/bare-metal/index.md
+++ b/Documentation/install/bare-metal/index.md
@@ -170,9 +170,9 @@ Make sure a current version of either the Google Chrome or Mozilla Firefox web b
 Download [Tectonic Installer][latest-tectonic-release].
 
 ```sh
-wget https://releases.tectonic.com/releases/tectonic_1.8.7-tectonic.2.zip
-unzip tectonic_1.8.7-tectonic.2.zip
-cd tectonic_1.8.7-tectonic.2/tectonic-installer
+wget https://releases.tectonic.com/releases/tectonic_1.7.14-tectonic.1.zip
+unzip tectonic_1.7.14-tectonic.1.zip
+cd tectonic_1.7.14-tectonic.1/tectonic-installer
 ```
 
 Run the Tectonic Installer for your platform:
@@ -225,7 +225,7 @@ After the installer is complete, you'll have a Tectonic cluster and be able to a
 [copr-repo]: https://copr.fedorainfracloud.org/coprs/g/CoreOS/matchbox/
 [coreos-release]: https://coreos.com/releases/
 [daemonset]: http://kubernetes.io/docs/admin/daemons/
-[latest-tectonic-release]: https://releases.tectonic.com/releases/tectonic_1.8.7-tectonic.2.zip
+[latest-tectonic-release]: https://releases.tectonic.com/releases/tectonic_1.7.14-tectonic.1.zip
 [matchbox-config]: https://coreos.com/matchbox/docs/latest/config.html
 [matchbox-dnsmasq]: https://github.com/coreos/matchbox/tree/master/contrib/dnsmasq
 [matchbox]: https://coreos.com/matchbox

--- a/Documentation/install/bare-metal/metal-terraform.md
+++ b/Documentation/install/bare-metal/metal-terraform.md
@@ -34,23 +34,23 @@ Once the update has processed, the *Overview* window will refresh to include lin
 Open a new terminal and run the following command to download Tectonic Installer.
 
 ```bash
-$ curl -O https://releases.tectonic.com/releases/tectonic_1.8.7-tectonic.2.zip
-$ curl -O https://releases.tectonic.com/releases/tectonic_1.8.7-tectonic.2.zip.sig
+$ curl -O https://releases.tectonic.com/releases/tectonic_1.7.14-tectonic.1.zip
+$ curl -O https://releases.tectonic.com/releases/tectonic_1.7.14-tectonic.1.zip.sig
 ```
 
 Verify the release has been signed by the [CoreOS App Signing Key][verification-key].
 
 ```bash
 $ gpg2 --keyserver pgp.mit.edu --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
-$ gpg2 --verify tectonic_1.8.7-tectonic.2.zip.sig tectonic_1.8.7-tectonic.2.zip
+$ gpg2 --verify tectonic_1.7.14-tectonic.1.zip.sig tectonic_1.7.14-tectonic.1.zip
 # gpg2: Good signature from "CoreOS Application Signing Key <security@coreos.com>"
 ```
 
 Unzip Tectonic Installer and navigate to the `tectonic` directory.
 
 ```bash
-$ unzip tectonic_1.8.7-tectonic.2.zip
-$ cd tectonic_1.8.7-tectonic.2
+$ unzip tectonic_1.7.14-tectonic.1.zip
+$ cd tectonic_1.7.14-tectonic.1
 ```
 
 ### Initialize and configure Terraform

--- a/Documentation/install/installer-windows.md
+++ b/Documentation/install/installer-windows.md
@@ -1,6 +1,6 @@
 # Running Tectonic Installer in a Docker container on Windows
 
-Tectonic v1.6.4 does not include an Installer binary for Windows. Windows users can install Tectonic by running an Installer container with Docker Community Edition (CE). This document describes how to use Docker CE on Windows to run Tectonic Installer to create Tectonic clusters on supported cloud providers or physical hardware.
+Tectonic v1.6.4 (and later) does not include an Installer binary for Windows. Windows users can install Tectonic by running an Installer container with Docker Community Edition (CE). This document describes how to use Docker CE on Windows to run Tectonic Installer to create Tectonic clusters on supported cloud providers or physical hardware.
 
 This document does not describe deploying Tectonic clusters on Windows hosts.
 
@@ -29,7 +29,7 @@ Type `cmd` in the Windows menu search box and press the Enter key. A new Windows
 Issue the following command to fetch and run the Tectonic Installer container image from the Quay registry:
 
 ```sh
-docker run --rm -p 4444:4444 -it quay.io/coreos/tectonic-installer:1.8.7-tectonic.2 /go/src/github.com/coreos/tectonic-installer/installer/bin/linux/installer -open-browser=false -address 0.0.0.0:4444
+docker run --rm -p 4444:4444 -it quay.io/coreos/tectonic-installer:1.7.14-tectonic.1 /go/src/github.com/coreos/tectonic-installer/installer/bin/linux/installer -open-browser=false -address 0.0.0.0:4444
 ```
 
 The status of the image download in progressively printed in the command window. Once Tectonic Installer is downloaded and running, `Starting Tectonic Installer on 0.0.0.0:4444` will be reported.
@@ -63,7 +63,7 @@ Type `cmd` into the Windows menu search box and press the Enter key. A new comma
 At the Windows command prompt, issue the command:
 
 ```sh
-docker run --rm -it -v %USERPROFILE%/Downloads:/Downloads quay.io/coreos/tectonic-installer:1.8.7-tectonic.2 bash
+docker run --rm -it -v %USERPROFILE%/Downloads:/Downloads quay.io/coreos/tectonic-installer:1.7.14-tectonic.1 bash
 ```
 
 The Installer container executes and presents a `bash` shell prompt within the container.

--- a/Documentation/install/openstack/openstack-terraform.md
+++ b/Documentation/install/openstack/openstack-terraform.md
@@ -36,23 +36,23 @@ Once the update has processed, the *Overview* window will refresh to include lin
 Open a new terminal and run the following command to download Tectonic Installer.
 
 ```bash
-$ curl -O https://releases.tectonic.com/releases/tectonic_1.8.7-tectonic.2.zip
-$ curl -O https://releases.tectonic.com/releases/tectonic_1.8.7-tectonic.2.zip.sig
+$ curl -O https://releases.tectonic.com/releases/tectonic_1.7.14-tectonic.1.zip
+$ curl -O https://releases.tectonic.com/releases/tectonic_1.7.14-tectonic.1.zip.sig
 ```
 
 Verify the release has been signed by the [CoreOS App Signing Key][verification-key].
 
 ```bash
 $ gpg2 --keyserver pgp.mit.edu --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
-$ gpg2 --verify tectonic_1.8.7-tectonic.2.zip.sig tectonic_1.8.7-tectonic.2.zip
+$ gpg2 --verify tectonic_1.7.14-tectonic.1.zip.sig tectonic_1.7.14-tectonic.1.zip
 # gpg2: Good signature from "CoreOS Application Signing Key <security@coreos.com>"
 ```
 
 Unzip Tectonic Installer and navigate to the `tectonic` directory.
 
 ```bash
-$ unzip tectonic_1.8.7-tectonic.2.zip
-$ cd tectonic_1.8.7-tectonic.2
+$ unzip tectonic_1.7.14-tectonic.1.zip
+$ cd tectonic_1.7.14-tectonic.1
 ```
 
 ### Initialize and configure Terraform

--- a/Documentation/install/vmware/vmware-terraform.md
+++ b/Documentation/install/vmware/vmware-terraform.md
@@ -78,23 +78,23 @@ The following steps must be executed on a machine that has network connectivity 
 Open a new terminal and run the following command to download Tectonic Installer.
 
 ```bash
-$ curl -O https://releases.tectonic.com/releases/tectonic_1.8.7-tectonic.2.zip
-$ curl -O https://releases.tectonic.com/releases/tectonic_1.8.7-tectonic.2.zip.sig
+$ curl -O https://releases.tectonic.com/releases/tectonic_1.7.14-tectonic.1.zip
+$ curl -O https://releases.tectonic.com/releases/tectonic_1.7.14-tectonic.1.zip.sig
 ```
 
 Verify the release has been signed by the [CoreOS App Signing Key][verification-key].
 
 ```bash
 $ gpg2 --keyserver pgp.mit.edu --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
-$ gpg2 --verify tectonic_1.8.7-tectonic.2.zip.sig tectonic_1.8.7-tectonic.2.zip
+$ gpg2 --verify tectonic_1.7.14-tectonic.1.zip.sig tectonic_1.7.14-tectonic.1.zip
 # gpg2: Good signature from "CoreOS Application Signing Key <security@coreos.com>"
 ```
 
 Unzip Tectonic Installer and navigate to the `tectonic` directory.
 
 ```bash
-$ unzip tectonic_1.8.7-tectonic.2.zip
-$ cd tectonic_1.8.7-tectonic.2
+$ unzip tectonic_1.7.14-tectonic.1.zip
+$ cd tectonic_1.7.14-tectonic.1
 ```
 
 ## Customize the deployment

--- a/Documentation/troubleshooting/faq.md
+++ b/Documentation/troubleshooting/faq.md
@@ -4,7 +4,7 @@
 
 The version number of a Tectonic release is a string in the format `W.X.Y-tectonic.z`, where `W.X.Y` stands for the Kubernetes version included with the release, and `z` is an incrementing number, starting at 1, for successive Tectonic releases including that Kubernetes version. When the version number of the included Kubernetes release changes, the incrementing value `z` resets to 1.
 
-For example, if the Kubernetes version is 1.8.7, the first Tectonic production release including it is labeled `1.8.7-tectonic.1`. A second release including the same 1.8.7 version of Kubernetes would be `1.8.7-tectonic.2`. When the version number of the included Kubernetes advances to 1.8.8, the associated Tectonic version number would be `1.8.8-tectonic.1`.
+For example, if the Kubernetes version is 1.7.14, the first Tectonic production release including it is labeled `1.7.14-tectonic.1`. A second release including the same 1.7.14 version of Kubernetes would be `1.7.14-tectonic.2`. When the version number of the included Kubernetes advances to 1.7.15, the associated Tectonic version number would be `1.7.15-tectonic.1`.
 
 ## License and pull-secret formats
 

--- a/Documentation/tutorials/aws/installing-tectonic.md
+++ b/Documentation/tutorials/aws/installing-tectonic.md
@@ -40,15 +40,15 @@ Make sure a current version of either Google Chrome or Mozilla Firefox is set as
 1. Download and run Tectonic Installer by opening a new terminal and running the following command:
 
 ```
-$ curl -O https://releases.tectonic.com/releases/tectonic_1.8.7-tectonic.2.zip
-$ curl -O https://releases.tectonic.com/releases/tectonic_1.8.7-tectonic.2.zip.sig
+$ curl -O https://releases.tectonic.com/releases/tectonic_1.7.14-tectonic.1.zip
+$ curl -O https://releases.tectonic.com/releases/tectonic_1.7.14-tectonic.1.zip.sig
 ```
 
 2. Verify the release has been signed by the [CoreOS App Signing Key][verification-key].
 
 ```bash
 $ gpg2 --keyserver pgp.mit.edu --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
-$ gpg2 --verify tectonic_1.8.7-tectonic.2.zip.sig tectonic_1.8.7-tectonic.2.zip
+$ gpg2 --verify tectonic_1.7.14-tectonic.1.zip.sig tectonic_1.7.14-tectonic.1.zip
 # gpg2: Good signature from "CoreOS Application Signing Key <security@coreos.com>"
 ```
 
@@ -62,8 +62,8 @@ When prompted, log in to your CoreOS account to obtain the License and Pull Secr
 
 If you prefer to work within the terminal, extract and launch the Installer using:
 ```bash
-$ unzip tectonic_1.8.7-tectonic.2.zip
-$ cd tectonic_1.8.7-tectonic.2/tectonic-installer # to change to the previously untarred directory
+$ unzip tectonic_1.7.14-tectonic.1.zip
+$ cd tectonic_1.7.14-tectonic.1/tectonic-installer # to change to the previously untarred directory
 $ ./$PLATFORM/installer # to run Tectonic Installer
 ```
 Where `$PLATFORM` is `linux` or `darwin`.

--- a/Documentation/tutorials/azure/install.md
+++ b/Documentation/tutorials/azure/install.md
@@ -131,23 +131,23 @@ $ ssh-add -L
 Open a new terminal and run the following command to download Tectonic Installer.
 
 ```bash
-$ curl -O https://releases.tectonic.com/releases/tectonic_1.8.7-tectonic.2.zip
-$ curl -O https://releases.tectonic.com/releases/tectonic_1.8.7-tectonic.2.zip.sig
+$ curl -O https://releases.tectonic.com/releases/tectonic_1.7.14-tectonic.1.zip
+$ curl -O https://releases.tectonic.com/releases/tectonic_1.7.14-tectonic.1.zip.sig
 ```
 
 Verify the release has been signed by the [CoreOS App Signing Key][verification-key].
 
 ```bash
 $ gpg2 --keyserver pgp.mit.edu --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
-$ gpg2 --verify tectonic_1.8.7-tectonic.2.zip.sig tectonic_1.8.7-tectonic.2.zip
+$ gpg2 --verify tectonic_1.7.14-tectonic.1.zip.sig tectonic_1.7.14-tectonic.1.zip
 # gpg2: Good signature from "CoreOS Application Signing Key <security@coreos.com>"
 ```
 
 Unzip Tectonic Installer and navigate to the `tectonic` directory.
 
 ```bash
-$ unzip tectonic_1.8.7-tectonic.2.zip
-$ cd tectonic_1.8.7-tectonic.2
+$ unzip tectonic_1.7.14-tectonic.1.zip
+$ cd tectonic_1.7.14-tectonic.1
 ```
 
 ### Create a cluster build directory


### PR DESCRIPTION
https://github.com/coreos/tectonic-docs/pull/147/files#diff-e86b3c97e885e3003b487ad4c8366610R3

**QUESTION**: Is the above true for all versions following 1.6.4 or does it only apply to 1.6.4?