### PR TITLE
Update docs for VMware install

### DIFF
--- a/Documentation/install/vmware/vmware-terraform.md
+++ b/Documentation/install/vmware/vmware-terraform.md
@@ -12,7 +12,7 @@ Generally, the VMware platform templates adhere to the standards defined by the 
 4. In the *Virtual Machine Configuration* view select "vApp Options" tab and un-check "Enable vApp Options".
 5. Convert the Container Linux image into a Virtual Machine template.
 6. Pre-allocate IP addresses for the cluster and create DNS records.
-7. Configure an existing Load Balancer for Tectonic. For an example setup, see [Using F5 BIG-IP LTM with Tectonic][using-f5].  This LB should proxy all requests on port 80 to port 32001 at the worker nodes and 443 requests to 32000.
+7. Configure an existing Load Balancer for Tectonic. For an example setup, see [Using F5 BIG-IP LTM with Tectonic][using-f5]. This LB should proxy all requests on port 80 to port 32001 at the worker nodes and 443 requests to 32000.
 
 ### DNS and IP address allocation
 
@@ -33,7 +33,7 @@ Create required DNS records before beginning setup. The following table lists 3 
 |mycluster-etcd-1.mycompany.com | A | 192.168.246.11 |
 |mycluster-etcd-2.mycompany.com | A | 192.168.246.12 |
 
-See [Tectonic on Baremetal DNS documentation][baremetaldns] for general DNS Requirements.  If you do *not* use a load balancer to route traffic to the tectonic ingress - and instead round-robin DNS - you will need to set the `ingress_kind` for the tectonic module in `platforms/vmware/tectonic.tf` to `HostPort` instead of `NodePort`.
+See [Tectonic on Baremetal DNS documentation][baremetaldns] for general DNS Requirements. If you do *not* use a load balancer to route traffic to the tectonic ingress - and instead round-robin DNS - you will need to set the `ingress_kind` for the tectonic module in `platforms/vmware/tectonic.tf` to `HostPort` instead of `NodePort`.
 
 ### Create a CoreOS account
 

--- a/Documentation/install/vmware/vmware-terraform.md
+++ b/Documentation/install/vmware/vmware-terraform.md
@@ -33,7 +33,7 @@ Create required DNS records before beginning setup. The following table lists 3 
 |mycluster-etcd-1.mycompany.com | A | 192.168.246.11 |
 |mycluster-etcd-2.mycompany.com | A | 192.168.246.12 |
 
-See [Tectonic on Baremetal DNS documentation][baremetaldns] for general DNS Requirements. If you do *not* use a load balancer to route traffic to the tectonic ingress - and instead round-robin DNS - you will need to set the `ingress_kind` for the tectonic module in `platforms/vmware/tectonic.tf` to `HostPort` instead of `NodePort`.
+See [Tectonic on Baremetal DNS documentation][baremetaldns] for general DNS Requirements. If you round-robin DNS, and do not use a load balancer to route traffic to Tectonic ingress, you must set `ingress_kind` for the Tectonic module in `platforms/vmware/tectonic.tf` to `HostPort`, rather than `NodePort`.
 
 ### Create a CoreOS account
 

--- a/Documentation/install/vmware/vmware-terraform.md
+++ b/Documentation/install/vmware/vmware-terraform.md
@@ -12,7 +12,7 @@ Generally, the VMware platform templates adhere to the standards defined by the 
 4. In the *Virtual Machine Configuration* view select "vApp Options" tab and un-check "Enable vApp Options".
 5. Convert the Container Linux image into a Virtual Machine template.
 6. Pre-allocate IP addresses for the cluster and create DNS records.
-7. For production clusters, configure an existing Load Balancer for Tectonic. For an example setup, see [Using F5 BIG-IP LTM with Tectonic][using-f5].
+7. Configure an existing Load Balancer for Tectonic. For an example setup, see [Using F5 BIG-IP LTM with Tectonic][using-f5].  This LB should proxy all requests on port 80 to port 32001 at the worker nodes and 443 requests to 32000.
 
 ### DNS and IP address allocation
 
@@ -33,7 +33,7 @@ Create required DNS records before beginning setup. The following table lists 3 
 |mycluster-etcd-1.mycompany.com | A | 192.168.246.11 |
 |mycluster-etcd-2.mycompany.com | A | 192.168.246.12 |
 
-See [Tectonic on Baremetal DNS documentation][baremetaldns] for general DNS Requirements.
+See [Tectonic on Baremetal DNS documentation][baremetaldns] for general DNS Requirements.  If you do *not* use a load balancer to route traffic to the tectonic ingress - and instead round-robin DNS - you will need to set the `ingress_kind` for the tectonic module in `platforms/vmware/tectonic.tf` to `HostPort` instead of `NodePort`.
 
 ### Create a CoreOS account
 

--- a/Documentation/reference/f5-ltm-lb.md
+++ b/Documentation/reference/f5-ltm-lb.md
@@ -47,7 +47,7 @@ Create an F5 LTM Pool for the API Server:
 Create an F5 LTM Pool for Tectonic console:
 1. From *Local Traffic > Pools*, click *Create*.
 2. Enter *Name: tectonic_console_443*.
-3. Under *New Members* add the IP address of all WORKER nodes (for example: `192.168.1.112` and `192.168.1.113`) and set *Service Port* to *443 / HTTPS*.  Note for VMware users: the tectonic ingress service uses `nodePort`, not `hostPort` so set the Service Port to 32000 instead of 443.
+3. Under *New Members* add the IP address of all WORKER nodes (for example: `192.168.1.112` and `192.168.1.113`) and set *Service Port* to *443 / HTTPS*. Note for VMware users: the tectonic ingress service uses `nodePort`, not `hostPort` so set the Service Port to 32000 instead of 443.
 4. Click *Finish* (leaving the rest of the settings at their default).
 
 ## Create F5 Virtual Servers

--- a/Documentation/reference/f5-ltm-lb.md
+++ b/Documentation/reference/f5-ltm-lb.md
@@ -47,7 +47,7 @@ Create an F5 LTM Pool for the API Server:
 Create an F5 LTM Pool for Tectonic console:
 1. From *Local Traffic > Pools*, click *Create*.
 2. Enter *Name: tectonic_console_443*.
-3. Under *New Members* add the IP address of all WORKER nodes (for example: `192.168.1.112` and `192.168.1.113`) and set *Service Port* to *443 / HTTPS*.
+3. Under *New Members* add the IP address of all WORKER nodes (for example: `192.168.1.112` and `192.168.1.113`) and set *Service Port* to *443 / HTTPS*.  Note for VMware users: the tectonic ingress service uses `nodePort`, not `hostPort` so set the Service Port to 32000 instead of 443.
 4. Click *Finish* (leaving the rest of the settings at their default).
 
 ## Create F5 Virtual Servers


### PR DESCRIPTION
The VMware platform now uses NodePort instead of HostPort for tectonic
ingress.  This update adds instructions related to this change.

Related issue: https://github.com/coreos/tectonic-installer/issues/3080