### PR TITLE
remove aggregator and apiserver_proxy parameters

### DIFF
--- a/Documentation/tls/tls-kube.md
+++ b/Documentation/tls/tls-kube.md
@@ -30,14 +30,11 @@ Configure the user provided certificate paths in your platform, i.e. `platforms/
 module "kube_certs" {
   source = "../../modules/tls/kube/user-provided"
 
-  aggregator_ca_cert_pem_path   = "/path/to/aggregator-ca.crt"
   ca_cert_pem_path              = "/path/to/ca.crt"
   kubelet_cert_pem_path         = "/path/to/kubelet.crt"
   kubelet_key_pem_path          = "/path/to/kubelet.key"
   apiserver_cert_pem_path       = "/path/to/apiserver.crt"
   apiserver_key_pem_path        = "/path/to/apiserver.key"
-  apiserver_proxy_cert_pem_path = "/path/to/apiserver-proxy.crt"
-  apiserver_proxy_key_pem_path  = "/path/to/apiserver-proxy.key"
 }
 ```
 


### PR DESCRIPTION
`tectonic 1.8.9` does not include self-signed variables for `aggregator_ca_cert_pem_path`, `apiserver_proxy_cert_pem_path`, and `apiserver_proxy_cert_key_path`.

If deploying Tectonic per [Provide Your Own Certificates](https://coreos.com/tectonic/docs/latest/tls/tls-certificates.html), failure to remove these in the `tls.tf` will result in following error during `terraform init platforms/aws`:

```
Downloading modules...
Error getting plugins: module root:
    module kube_certs: apiserver_proxy_cert_pem_path is not a valid parameter
    module kube_certs: apiserver_proxy_key_pem_path is not a valid parameter
    module kube_certs: aggregator_ca_cert_pem_path is not a valid parameter
```

Confirmed that one can successfully do a 'provide your own certificates' tectonic install without them.